### PR TITLE
Transformer hooks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 group :development, :test do
   gem "rspec-rails", "~> 3.9"
   gem "capybara", "~> 2.18"
+  gem "factory_bot_rails", "~> 5.1"
   gem "sqlite3", "~> 1.4"
   gem "pry-byebug", "~> 3.8"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem "rspec-rails", "~> 3.9"
   gem "capybara", "~> 2.18"
   gem "factory_bot_rails", "~> 5.1"
+  gem "timecop", "~> 0.9.1"
   gem "sqlite3", "~> 1.4"
   gem "pry-byebug", "~> 3.8"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     websocket-driver (0.7.1)
@@ -211,6 +212,7 @@ DEPENDENCIES
   pry-byebug (~> 3.8)
   rspec-rails (~> 3.9)
   sqlite3 (~> 1.4)
+  timecop (~> 0.9.1)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,11 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     erubi (1.9.0)
+    factory_bot (5.1.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.3.0)
@@ -200,6 +205,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara (~> 2.18)
+  factory_bot_rails (~> 5.1)
   jeweler (~> 2.1)
   odata_server!
   pry-byebug (~> 3.8)
@@ -207,4 +213,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ Restart your sever and you can visit the `/service/Odata` url that is the servic
 See https://github.com/lmcalpin/odata_provider_example_rb for an example application that
 uses this gem.
 
+## Other options
+
+In addition to `:classes` and `:reflection`, you can use:
+
+- `:transformers`: Hash allowing the following data transformer hooks (ActiveRecord only for now):
+    - `:root`: Transform the JSON before output for `/`
+    - `:metadata`: Transform the schema before output to XML for `/$metadata`
+    - `:feed`: Transform the JSON before output for a resource feed, e.g. `/Categories`
+    - `:entry`: Transform the JSON before output for a resource entry, e.g. `/Categories(1)`
+
 ## TODOS
 
 * Update the core for OData v4

--- a/app/controllers/o_data_controller.rb
+++ b/app/controllers/o_data_controller.rb
@@ -28,11 +28,12 @@ class ODataController < ApplicationController
     respond_to do |format|
       format.xml  # service.xml.builder
       format.json do
+        schema = @@data_services.schemas.first
         json = {
           "@odata.context" => o_data_engine.metadata_url,
           value: @@data_services.to_json
         }
-        render json: json
+        render json: schema.transform_json_for_root(json)
       end
     end
   end

--- a/app/controllers/o_data_controller.rb
+++ b/app/controllers/o_data_controller.rb
@@ -33,7 +33,7 @@ class ODataController < ApplicationController
           "@odata.context" => o_data_engine.metadata_url,
           value: @@data_services.to_json
         }
-        render json: schema.transform_json_for_root(json)
+        render json: schema.transformers[:root].call(json)
       end
     end
   end

--- a/app/helpers/resource_json_renderer_helper.rb
+++ b/app/helpers/resource_json_renderer_helper.rb
@@ -10,7 +10,7 @@ module ResourceJsonRendererHelper
     end
 
     json[:value] = results.collect { |result| o_data_json_entry(query, result, entity_type, options) }
-    entity_type.schema.transform_json_for_resource_feed(json)
+    entity_type.schema.transformers[:feed].call(json)
   end
 
   def o_data_json_entry(query, result, entity_type, options = {})
@@ -39,7 +39,7 @@ module ResourceJsonRendererHelper
       end
     end
 
-    entity_type.schema.transform_json_for_resource_entry(_json)
+    entity_type.schema.transformers[:entry].call(_json)
   end
 
 end

--- a/app/helpers/resource_json_renderer_helper.rb
+++ b/app/helpers/resource_json_renderer_helper.rb
@@ -10,7 +10,7 @@ module ResourceJsonRendererHelper
     end
 
     json[:value] = results.collect { |result| o_data_json_entry(query, result, entity_type, options) }
-    json
+    entity_type.schema.transform_json_for_resource_feed(json)
   end
 
   def o_data_json_entry(query, result, entity_type, options = {})
@@ -39,7 +39,7 @@ module ResourceJsonRendererHelper
       end
     end
 
-    _json
+    entity_type.schema.transform_json_for_resource_entry(_json)
   end
 
 end

--- a/app/views/o_data/metadata.xml.builder
+++ b/app/views/o_data/metadata.xml.builder
@@ -3,7 +3,7 @@ xml.edmx(:Edmx, Version: "4.0", "xmlns:edmx" => "http://docs.oasis-open.org/odat
   xml.edmx(:DataServices) do
 
     ODataController.data_services.schemas.each do |schema|
-      schema = schema.transformed_for_metadata
+      schema = schema.transformers[:metadata].call(schema)
 
       xml.tag!(:Schema, Namespace: schema.namespace, xmlns: "http://docs.oasis-open.org/odata/ns/edm") do
 

--- a/app/views/o_data/metadata.xml.builder
+++ b/app/views/o_data/metadata.xml.builder
@@ -3,6 +3,8 @@ xml.edmx(:Edmx, Version: "4.0", "xmlns:edmx" => "http://docs.oasis-open.org/odat
   xml.edmx(:DataServices) do
 
     ODataController.data_services.schemas.each do |schema|
+      schema = schema.transformed_for_metadata
+
       xml.tag!(:Schema, Namespace: schema.namespace, xmlns: "http://docs.oasis-open.org/odata/ns/edm") do
 
         schema.entity_types.values.sort_by(&:qualified_name).each do |entity_type|

--- a/lib/o_data/active_record_schema/base.rb
+++ b/lib/o_data/active_record_schema/base.rb
@@ -7,6 +7,10 @@ module OData
         super(namespace)
         @classes = Array(options[:classes])
         @reflection = options[:reflection] || false
+        @transform_json_for_root = options[:transform_json_for_root] || nil
+        @transform_schema_for_metadata = options[:transform_schema_for_metadata] || nil
+        @transform_json_for_resource_feed = options[:transform_json_for_resource_feed] || nil
+        @transform_json_for_resource_entry = options[:transform_json_for_resource_entry] || nil
 
         if classes.any?
           path = classes.map { |klass| Rails.root.to_s + "/app/models/#{klass}.rb" }
@@ -33,6 +37,22 @@ module OData
         entity_type = EntityType.new(self, *args)
         @entity_types[entity_type.name] = entity_type
         entity_type
+      end
+
+      def transform_json_for_root(json)
+        @transform_json_for_root ? @transform_json_for_root.call(json) : json
+      end
+
+      def transformed_for_metadata
+        @transform_schema_for_metadata ? @transform_schema_for_metadata.call(self) : self
+      end
+
+      def transform_json_for_resource_feed(json)
+        @transform_json_for_resource_feed ? @transform_json_for_resource_feed.call(json) : json
+      end
+
+      def transform_json_for_resource_entry(json)
+        @transform_json_for_resource_entry ? @transform_json_for_resource_entry.call(json) : json
       end
     end
   end

--- a/lib/o_data/active_record_schema/base.rb
+++ b/lib/o_data/active_record_schema/base.rb
@@ -7,6 +7,9 @@ module OData
         super(namespace)
         @classes = Array(options[:classes])
         @reflection = options[:reflection] || false
+
+        # Hooks.
+        # See spec/requests/ for examples of how these can be used.
         @transform_json_for_root = options[:transform_json_for_root] || nil
         @transform_schema_for_metadata = options[:transform_schema_for_metadata] || nil
         @transform_json_for_resource_feed = options[:transform_json_for_resource_feed] || nil
@@ -40,19 +43,19 @@ module OData
       end
 
       def transform_json_for_root(json)
-        @transform_json_for_root ? @transform_json_for_root.call(json) : json
+        @transform_json_for_root&.call(json) || json
       end
 
       def transformed_for_metadata
-        @transform_schema_for_metadata ? @transform_schema_for_metadata.call(self) : self
+        @transform_schema_for_metadata&.call(self) || self
       end
 
       def transform_json_for_resource_feed(json)
-        @transform_json_for_resource_feed ? @transform_json_for_resource_feed.call(json) : json
+        @transform_json_for_resource_feed&.call(json) || json
       end
 
       def transform_json_for_resource_entry(json)
-        @transform_json_for_resource_entry ? @transform_json_for_resource_entry.call(json) : json
+        @transform_json_for_resource_entry&.call(json) || json
       end
     end
   end

--- a/lib/o_data/active_record_schema/base.rb
+++ b/lib/o_data/active_record_schema/base.rb
@@ -1,19 +1,20 @@
 module OData
   module ActiveRecordSchema
     class Base < OData::AbstractSchema::Base
-      attr_reader :classes, :reflection
+      attr_reader :classes, :reflection, :transformers
 
       def initialize(namespace = 'OData', options = {})
         super(namespace)
         @classes = Array(options[:classes])
         @reflection = options[:reflection] || false
-
-        # Hooks.
+        # Data transformer hooks.
         # See spec/requests/ for examples of how these can be used.
-        @transform_json_for_root = options[:transform_json_for_root] || nil
-        @transform_schema_for_metadata = options[:transform_schema_for_metadata] || nil
-        @transform_json_for_resource_feed = options[:transform_json_for_resource_feed] || nil
-        @transform_json_for_resource_entry = options[:transform_json_for_resource_entry] || nil
+        @transformers = options[:transformers] || {}
+        noop = ->(x) { x }
+        @transformers[:metadata] ||= noop
+        @transformers[:root] ||= noop
+        @transformers[:feed] ||= noop
+        @transformers[:entry] ||= noop
 
         if classes.any?
           path = classes.map { |klass| Rails.root.to_s + "/app/models/#{klass}.rb" }
@@ -40,22 +41,6 @@ module OData
         entity_type = EntityType.new(self, *args)
         @entity_types[entity_type.name] = entity_type
         entity_type
-      end
-
-      def transform_json_for_root(json)
-        @transform_json_for_root&.call(json) || json
-      end
-
-      def transformed_for_metadata
-        @transform_schema_for_metadata&.call(self) || self
-      end
-
-      def transform_json_for_resource_feed(json)
-        @transform_json_for_resource_feed&.call(json) || json
-      end
-
-      def transform_json_for_resource_entry(json)
-        @transform_json_for_resource_entry&.call(json) || json
       end
     end
   end

--- a/lib/o_data/edm/data_services.rb
+++ b/lib/o_data/edm/data_services.rb
@@ -1,6 +1,7 @@
 module OData
   module Edm
     class DataServices
+      # Initial schemas that can be added statically.
       cattr_accessor :schemas
       @@schemas = []
 

--- a/lib/o_data/edm/data_services.rb
+++ b/lib/o_data/edm/data_services.rb
@@ -12,6 +12,11 @@ module OData
         append_schemas(schemas.dup || [])
       end
 
+      def clear_schemas
+        @entity_types.clear
+        @schemas.clear
+      end
+
       def append_schemas(schemas)
         @schemas.concat(schemas)
         schemas.each do |schema|

--- a/lib/o_data/edm/data_services.rb
+++ b/lib/o_data/edm/data_services.rb
@@ -8,7 +8,12 @@ module OData
 
       def initialize(schemas = @@schemas)
         @entity_types = []
-        @schemas = schemas.dup || []
+        @schemas = []
+        append_schemas(schemas.dup || [])
+      end
+
+      def append_schemas(schemas)
+        @schemas.concat(schemas)
         schemas.each do |schema|
           @entity_types.concat(schema.entity_types.values)
         end

--- a/spec/dummy/app/models/active_bar.rb
+++ b/spec/dummy/app/models/active_bar.rb
@@ -1,0 +1,2 @@
+class ActiveBar < ApplicationRecord
+end

--- a/spec/dummy/app/models/active_foo.rb
+++ b/spec/dummy/app/models/active_foo.rb
@@ -1,0 +1,2 @@
+class ActiveFoo < ApplicationRecord
+end

--- a/spec/dummy/db/migrate/20200410044413_create_active_foos.rb
+++ b/spec/dummy/db/migrate/20200410044413_create_active_foos.rb
@@ -1,0 +1,9 @@
+class CreateActiveFoos < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_foos do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20200410044417_create_active_bars.rb
+++ b/spec/dummy/db/migrate/20200410044417_create_active_bars.rb
@@ -1,0 +1,9 @@
+class CreateActiveBars < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_bars do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,6 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_04_10_044417) do
+
+  create_table "active_bars", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "active_foos", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/dummy/spec/factories/active_bars.rb
+++ b/spec/dummy/spec/factories/active_bars.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :active_bar do
+    
+  end
+end

--- a/spec/dummy/spec/factories/active_foos.rb
+++ b/spec/dummy/spec/factories/active_foos.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :active_foo do
+    
+  end
+end

--- a/spec/fixtures/files/metadata_after_hook.xml
+++ b/spec/fixtures/files/metadata_after_hook.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Test2" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="ActiveBar">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="true"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="ActiveFoo">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="TestType" Nullable="true"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="Test2Service">
+        <EntitySet Name="ActiveBars" EntityType="Test2.ActiveBar">
+        </EntitySet>
+        <EntitySet Name="ActiveFoos" EntityType="Test2.ActiveFoo">
+        </EntitySet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/spec/fixtures/files/metadata_basic.xml
+++ b/spec/fixtures/files/metadata_basic.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Test" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="ActiveBar">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="true"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="ActiveFoo">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="true"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="TestService">
+        <EntitySet Name="ActiveBars" EntityType="Test.ActiveBar">
+        </EntitySet>
+        <EntitySet Name="ActiveFoos" EntityType="Test.ActiveFoo">
+        </EntitySet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/spec/lib/odata/active_record_schema/active_record_schema_spec.rb
+++ b/spec/lib/odata/active_record_schema/active_record_schema_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe OData::ActiveRecordSchema::Base do
+  context "initialize" do
+    it "creates a new schema without entities in the OData namespace by default" do
+      schema = OData::ActiveRecordSchema::Base.new
+      expect(schema.namespace).to eq("OData")
+    end
+
+    it "a namespace argument" do
+      schema = OData::ActiveRecordSchema::Base.new("TestNamespace")
+      expect(schema.namespace).to eq("TestNamespace")
+    end
+
+    it "registers entity types passed via the :classes option" do
+      schema = OData::ActiveRecordSchema::Base.new("TestNamespace", classes: [ActiveFoo, ActiveBar])
+      expect(schema.entity_types.keys).to contain_exactly("ActiveFoo", "ActiveBar")
+    end
+  end
+
+  context "find_entites" do
+    let(:schema) { OData::ActiveRecordSchema::Base.new("TestNamespace", classes: [ActiveFoo, ActiveBar]) }
+
+    it "accepts classes or class names" do
+      expect(schema.find_entity_type("ActiveFoo").name).to eq("ActiveFoo")
+      expect(schema.find_entity_type(ActiveFoo).name).to eq("ActiveFoo")
+    end
+
+    it "gives access to all entities of a given entity type" do
+      foo_entity_type = schema.find_entity_type("ActiveFoo")
+      (1..20).each do |n|
+        create(:active_foo, name: "test #{n}")
+      end
+      expect(foo_entity_type.active_record.all.size).to eq(20)
+      foo_entity_type.active_record.all.each do |foo|
+        expect(foo_entity_type.find_one(foo.id)).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end
 
 ## Test entity

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -7,11 +7,13 @@ describe OData::ActiveRecordSchema::Base do
     let(:schema) { OData::ActiveRecordSchema::Base.new("Test", classes: [ActiveFoo, ActiveBar], **options) }
 
     before do
+      Timecop.freeze("2020-01-01T12:00Z")
       ODataController.data_services.append_schemas([schema])
     end
 
     after do
       ODataController.data_services.clear_schemas
+      Timecop.return
     end
 
     def expect_output(expected)

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -2,25 +2,57 @@ require "rails_helper"
 
 describe OData::ActiveRecordSchema::Base do
   context "render" do
-    let(:root) { "/odata" }
-    let(:schema) { OData::ActiveRecordSchema::Base.new("Test", classes: [ActiveFoo, ActiveBar]) }
+    let(:options) { {} }
+    let(:schema) { OData::ActiveRecordSchema::Base.new("Test", classes: [ActiveFoo, ActiveBar], **options) }
 
     before do
       ODataController.data_services.append_schemas([schema])
     end
 
-    it "root" do
-      expected = {
-        "@odata.context" => "http://www.example.com/odata/$metadata",
-        value: [
-          { name: "ActiveFoos", kind: "EntitySet", url: "ActiveFoos" },
-          { name: "ActiveBars", kind: "EntitySet", url: "ActiveBars" }
-        ]
-      }.to_json
+    after do
+      ODataController.data_services.clear_schemas
+    end
 
-      get(root)
+    def expect_output(expected)
+      get(path)
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(expected)
+    end
+
+    context "root" do
+      let(:path) { "/odata" }
+
+      it "renders as expected" do
+        expect_output({
+          "@odata.context" => "http://www.example.com/odata/$metadata",
+          value: [
+            { name: "ActiveFoos", kind: "EntitySet", url: "ActiveFoos" },
+            { name: "ActiveBars", kind: "EntitySet", url: "ActiveBars" }
+          ]
+        }.to_json)
+      end
+
+      context "with hook" do
+        let(:options) do
+          {
+            transform_json_for_root: lambda do |json|
+              json[:value].push({ name: "Fake data" })
+              json
+            end
+          }
+        end
+
+        it "renders as expected" do
+          expect_output({
+            "@odata.context" => "http://www.example.com/odata/$metadata",
+            value: [
+              { name: "ActiveFoos", kind: "EntitySet", url: "ActiveFoos" },
+              { name: "ActiveBars", kind: "EntitySet", url: "ActiveBars" },
+              { name: "Fake data" }
+            ]
+          }.to_json)
+        end
+      end
     end
   end
 end

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -39,10 +39,12 @@ describe OData::ActiveRecordSchema::Base do
       context "with hook" do
         let(:options) do
           {
-            transform_json_for_root: lambda do |json|
-              json[:value].push({ name: "Fake data" })
-              json
-            end
+            transformers: {
+              root: lambda do |json|
+                json[:value].push({ name: "Fake data" })
+                json
+              end
+            }
           }
         end
 
@@ -69,11 +71,13 @@ describe OData::ActiveRecordSchema::Base do
       context "with hook" do
         let(:options) do
           {
-            transform_schema_for_metadata: lambda do |schema|
-              schema.namespace = "Test2"
-              schema.entity_types["ActiveFoo"].properties["Name"] = SimpleProperty.new("Name")
-              schema
-            end
+            transformers: {
+              metadata: lambda do |schema|
+                schema.namespace = "Test2"
+                schema.entity_types["ActiveFoo"].properties["Name"] = SimpleProperty.new("Name")
+                schema
+              end
+            }
           }
         end
 
@@ -105,10 +109,12 @@ describe OData::ActiveRecordSchema::Base do
       context "with feed hook" do
         let(:options) do
           {
-            transform_json_for_resource_feed: lambda do |json|
-              json[:value].push({ name: "Fake data" })
-              json
-            end
+            transformers: {
+              feed: lambda do |json|
+                json[:value].push({ name: "Fake data" })
+                json
+              end
+            }
           }
         end
 
@@ -127,10 +133,12 @@ describe OData::ActiveRecordSchema::Base do
       context "with entry hook" do
         let(:options) do
           {
-            transform_json_for_resource_entry: lambda do |json|
-              json["Name"] = "foo"
-              json
-            end
+            transformers: {
+              entry: lambda do |json|
+                json["Name"] = "foo"
+                json
+              end
+            }
           }
         end
 

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -19,7 +19,8 @@ describe OData::ActiveRecordSchema::Base do
     def expect_output(expected)
       get(path)
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq(expected)
+      # Don't worry about trailing newlines.
+      expect(response.body.rstrip).to eq(expected.rstrip)
     end
 
     context "root" do
@@ -78,6 +79,69 @@ describe OData::ActiveRecordSchema::Base do
 
         it "renders as expected" do
           expect_output(file_fixture("metadata_after_hook.xml").read)
+        end
+      end
+    end
+
+    context "resource" do
+      let(:path) { "#{root}/ActiveFoos" }
+
+      before do
+        (1..2).each do |n|
+          create(:active_foo, name: "test #{n}")
+        end
+      end
+
+      it "renders as expected" do
+        expect_output({
+          "@odata.context": "http://www.example.com/odata/$metadata#ActiveFoos",
+          value: [
+            { Id: 1, Name: "test 1", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+            { Id: 2, Name: "test 2", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" }
+          ]
+        }.to_json)
+      end
+
+      context "with feed hook" do
+        let(:options) do
+          {
+            transform_json_for_resource_feed: lambda do |json|
+              json[:value].push({ name: "Fake data" })
+              json
+            end
+          }
+        end
+
+        it "renders as expected" do
+          expect_output({
+            "@odata.context": "http://www.example.com/odata/$metadata#ActiveFoos",
+            value: [
+              { Id: 1, Name: "test 1", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+              { Id: 2, Name: "test 2", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+              { name: "Fake data" }
+            ]
+          }.to_json)
+        end
+      end
+
+      context "with entry hook" do
+        let(:options) do
+          {
+            transform_json_for_resource_entry: lambda do |json|
+              json["Name"] = "foo"
+              json
+            end
+          }
+        end
+
+        it "renders as expected" do
+          expect_output({
+            "@odata.context": "http://www.example.com/odata/$metadata#ActiveFoos",
+            value: [
+              { Id: 1, Name: "foo", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+              { Id: 2, Name: "foo", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+            ]
+          }.to_json)
         end
       end
     end

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe OData::ActiveRecordSchema::Base do
+  context "render" do
+    let(:root) { "/odata" }
+    let(:schema) { OData::ActiveRecordSchema::Base.new("Test", classes: [ActiveFoo, ActiveBar]) }
+
+    before do
+      ODataController.data_services.append_schemas([schema])
+    end
+
+    it "root" do
+      expected = {
+        "@odata.context" => "http://www.example.com/odata/$metadata",
+        value: [
+          { name: "ActiveFoos", kind: "EntitySet", url: "ActiveFoos" },
+          { name: "ActiveBars", kind: "EntitySet", url: "ActiveBars" }
+        ]
+      }.to_json
+
+      get(root)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

1. We have a lot of columns in our database, and not all of them are useful (or safe) to expose via the API
1. We have recursively nested data (related to online survey submissions), and we'd like to use internal business logic to modify the metadata XML instead of trying to cram that logic into your nice generic engine
1. Our schema can change based on user activity (creating new entities dynamically)

Our solution is to **tweak things at request time**, and hooks allow us to accomplish all of this and more without changing too much logic in the odata_server engine itself.

We already have this working in production successfully.

### Main changes

In addition to the existing `:classes` and `:reflection` options, you can now use:

- `:transformers`: Hash allowing the following data transformer hooks (ActiveRecord only for now):
    - `:root`: Transform the JSON before output for `/`
    - `:metadata`: Transform the schema before output to XML for `/$metadata`
    - `:feed`: Transform the JSON before output for a resource feed, e.g. for `/Categories`
    - `:entry`: Transform the JSON before output for a resource entry, e.g. for each individual item in `/Categories`, or for `/Categories(1)`

See specs for example implementations, e.g.:

```ruby
transformers: {
  root: lambda do |json|
    json[:value].push({ name: "Fake data" })
    json
  end
}
```

### Secondary changes

Add basic specs for `active_record_schema` similar to the existing specs for `in_memory_schema`.
