### PR TITLE
Fix deprecated render `text` => `plain`

### DIFF
--- a/app/controllers/o_data_controller.rb
+++ b/app/controllers/o_data_controller.rb
@@ -44,7 +44,7 @@ class ODataController < ApplicationController
   end
 
   def options
-    render text: 'Allow: GET', status: :ok
+    render plain: 'Allow: GET', status: :ok
   end
 
   def resource
@@ -53,9 +53,9 @@ class ODataController < ApplicationController
 
     case @last_segment.class.segment_name
     when OData::Core::Segments::CountSegment.segment_name
-      render text: @results.to_i
+      render plain: @results.to_i
     when OData::Core::Segments::ValueSegment.segment_name
-      render text: @results.to_s
+      render plain: @results.to_s
     when OData::Core::Segments::PropertySegment.segment_name
       path = @query.segments.map(&:value).join('/')
 


### PR DESCRIPTION
Fixes e.g. `/$count`, which previously fell back to trying to render `resource.json.erb` because `text` wasn't a valid response type. Interestingly, the invalid response type didn't throw up any errors.

Reference: https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-text