### PR TITLE
Allow manually adding EntityTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ In addition to `:classes` and `:reflection`, you can use:
     - `:metadata`: Transform the schema before output to XML for `/$metadata`
     - `:feed`: Transform the JSON before output for a resource feed, e.g. `/Categories`
     - `:entry`: Transform the JSON before output for a resource entry, e.g. `/Categories(1)`
+- `:skip_require`: `true` if you want to skip automatically requiring each ActiveRecord class (for example if your app loads them itself)
+- `:skip_add_entity_types`: `true` if you want to skip automatically adding an EntityType for each ActiveRecord class (you must add them manually, which allows you to customize things like `:name` and `:where`)
 
 ## TODOS
 

--- a/lib/o_data/active_record_schema/base.rb
+++ b/lib/o_data/active_record_schema/base.rb
@@ -30,8 +30,10 @@ module OData
           Dir.glob(path).each { |file| require file }
         end
 
-        models.map do |active_record|
-          self.EntityType(active_record, reflect_on_associations: reflection)
+        return if options[:skip_add_entity_types]
+
+        models.each do |active_record|
+          add_entity_type(active_record, reflect_on_associations: reflection)
         end
       end
 
@@ -39,10 +41,9 @@ module OData
         entity_types[EntityType.name_for(klass)]
       end
 
-      def EntityType(*args)
+      def add_entity_type(*args)
         entity_type = EntityType.new(self, *args)
         @entity_types[entity_type.name] = entity_type
-        entity_type
       end
     end
   end

--- a/lib/o_data/active_record_schema/base.rb
+++ b/lib/o_data/active_record_schema/base.rb
@@ -26,7 +26,9 @@ module OData
           end
         end
 
-        Dir.glob(path).each { |file| require file }
+        unless options[:skip_require]
+          Dir.glob(path).each { |file| require file }
+        end
 
         models.map do |active_record|
           self.EntityType(active_record, reflect_on_associations: reflection)

--- a/lib/o_data/active_record_schema/entity_type.rb
+++ b/lib/o_data/active_record_schema/entity_type.rb
@@ -21,9 +21,9 @@ module OData
       def initialize(schema, active_record, options = {})
         super(schema, self.class.name_for(active_record))
 
-        options.reverse_merge!(:reflect_on_associations => true)
+        options.reverse_merge!(reflect_on_associations: true, where: {})
 
-        @active_record = active_record
+        @active_record = active_record.where(options[:where])
 
         key_property_name = self.class.primary_key_for(@active_record).to_s
 

--- a/lib/o_data/active_record_schema/entity_type.rb
+++ b/lib/o_data/active_record_schema/entity_type.rb
@@ -19,9 +19,11 @@ module OData
       attr_reader :active_record
 
       def initialize(schema, active_record, options = {})
-        super(schema, self.class.name_for(active_record))
+        options.reverse_merge!(reflect_on_associations: true,
+                               name: self.class.name_for(active_record),
+                               where: {})
 
-        options.reverse_merge!(reflect_on_associations: true, where: {})
+        super(schema, options[:name])
 
         @active_record = active_record.where(options[:where])
 


### PR DESCRIPTION
### Motivation

1. Our schema can change based on user activity (creating new entities dynamically), so we'd like to be able to add entity types manually rather than relying on them being generated during initialization.
1. We want to be able to split up certain entities -- for example, split the single `User` table into separate OData endpoints for `Admin` and `Customer`

We already have this code working in production successfully.

### Changes

In addition to the existing `:classes` and `:reflection` options, you can now use:

- `:skip_require`: `true` if you want to skip automatically requiring each ActiveRecord class (for example if your app loads them itself)
- `:skip_add_entity_types`: `true` if you want to skip automatically adding an EntityType for each ActiveRecord class (you must add them manually, which allows you to customize things like `:name` and `:where`)

EntityType also supports these new options (mentioned above):
- `:name`, e.g. `schema.add_entity_type(ActiveFoo, name: "CustomFoo")`
- `:where`, e.g. `schema.add_entity_type(ActiveFoo, where: { admin: true })`

See specs for example implementations.
