### PR TITLE
Features for customizing $metadata (and supporting tweaks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore local bundle installs.
+/vendor/bundle/
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/app/controllers/o_data_controller.rb
+++ b/app/controllers/o_data_controller.rb
@@ -13,6 +13,11 @@ class ODataController < ApplicationController
 
   skip_before_action :verify_authenticity_token, only: :options
 
+  # This action needs to register first.
+  # Clients may override the method if they want to do something.
+  before_action :before_action
+  def before_action; end
+
   before_action :parse_url, only: :resource
   before_action :set_request_format!, only: :resource
   after_action :set_header

--- a/app/controllers/o_data_controller.rb
+++ b/app/controllers/o_data_controller.rb
@@ -13,10 +13,10 @@ class ODataController < ApplicationController
 
   skip_before_action :verify_authenticity_token, only: :options
 
-  # This action needs to register first.
-  # Clients may override the method if they want to do something.
-  before_action :before_action
-  def before_action; end
+  # This action needs to register before the others.
+  # Clients may override the method if they want to do something with it.
+  before_action :refresh_schema
+  def refresh_schema; end
 
   before_action :parse_url, only: :resource
   before_action :set_request_format!, only: :resource

--- a/app/views/o_data/metadata.xml.builder
+++ b/app/views/o_data/metadata.xml.builder
@@ -9,7 +9,7 @@ xml.edmx(:Edmx, Version: "4.0", "xmlns:edmx" => "http://docs.oasis-open.org/odat
 
         schema.entity_types.values.sort_by(&:qualified_name).each do |entity_type|
           next if entity_type.name.include?('HABTM')
-          xml.tag!(:EntityType, Name: entity_type.name) do
+          xml.tag!(:EntityType, Name: entity_type.name, **entity_type.extra_tags) do
             unless entity_type.key_property.blank?
               xml.tag!(:Key) do
                 xml.tag!(:PropertyRef, Name: entity_type.key_property.name)

--- a/lib/o_data/abstract_schema/base.rb
+++ b/lib/o_data/abstract_schema/base.rb
@@ -7,10 +7,12 @@ module OData
 
       attr_accessor :namespace
       attr_accessor :entity_types
+      attr_accessor :entity_type_aliases
 
       def initialize(namespace = "OData")
         @namespace = namespace
         @entity_types = {}
+        @entity_type_aliases = {}
       end
 
       def EntityType(*args)

--- a/lib/o_data/abstract_schema/entity_type.rb
+++ b/lib/o_data/abstract_schema/entity_type.rb
@@ -8,7 +8,7 @@ module OData
       include Mixins::Schematize
 
       attr_reader :key_property, :schema
-      attr_accessor :properties, :navigation_properties
+      attr_accessor :properties, :navigation_properties, :extra_tags
 
       def self.name_for(object)
         object.class.to_s.gsub('::', '')
@@ -20,6 +20,7 @@ module OData
         @properties = {}
         @key_property = nil
         @navigation_properties = {}
+        @extra_tags = {}
       end
 
       def key_property=(property)

--- a/lib/o_data/abstract_schema/mixins/schematize.rb
+++ b/lib/o_data/abstract_schema/mixins/schematize.rb
@@ -28,6 +28,9 @@ module OData
           name.pluralize
         end
 
+        def url_name
+          @url_name || plural_name
+        end
       end
     end
   end

--- a/lib/o_data/active_record_schema/base.rb
+++ b/lib/o_data/active_record_schema/base.rb
@@ -38,12 +38,15 @@ module OData
       end
 
       def find_entity_type(klass)
-        entity_types[EntityType.name_for(klass)]
+        name = EntityType.name_for(klass)
+        entity_types[name] || entity_type_aliases[name]
       end
 
-      def add_entity_type(*args)
-        entity_type = EntityType.new(self, *args)
+      def add_entity_type(active_record, url_name: nil, **options)
+        entity_type = EntityType.new(self, active_record, url_name: url_name, **options)
         @entity_types[entity_type.name] = entity_type
+        # Alias the entity for fast lookup via URL path.
+        @entity_type_aliases[url_name.singularize] = entity_type if url_name
       end
     end
   end

--- a/lib/o_data/active_record_schema/entity_type.rb
+++ b/lib/o_data/active_record_schema/entity_type.rb
@@ -21,10 +21,12 @@ module OData
       def initialize(schema, active_record, options = {})
         options.reverse_merge!(reflect_on_associations: true,
                                name: self.class.name_for(active_record),
+                               url_name: nil,
                                where: {})
 
         super(schema, options[:name])
 
+        @url_name = options[:url_name]
         @active_record = active_record.where(options[:where])
 
         key_property_name = self.class.primary_key_for(@active_record).to_s

--- a/lib/o_data/active_record_schema/property.rb
+++ b/lib/o_data/active_record_schema/property.rb
@@ -11,6 +11,7 @@ module OData
         :timestamp => 'Edm.DateTimeOffset',
         :float     => 'Edm.Decimal',
         :decimal   => 'Edm.Decimal',
+        :id        => 'Edm.Guid',
         :integer   => 'Edm.Int64',
         :string    => 'Edm.String',
         :text      => 'Edm.String',

--- a/lib/o_data/active_record_schema/property.rb
+++ b/lib/o_data/active_record_schema/property.rb
@@ -11,7 +11,7 @@ module OData
         :timestamp => 'Edm.DateTimeOffset',
         :float     => 'Edm.Decimal',
         :decimal   => 'Edm.Decimal',
-        :integer   => 'Edm.Int32',
+        :integer   => 'Edm.Int64',
         :string    => 'Edm.String',
         :text      => 'Edm.String',
         :time      => 'Edm.TimeOfDay'

--- a/lib/o_data/core/segments/collection_segment.rb
+++ b/lib/o_data/core/segments/collection_segment.rb
@@ -7,6 +7,7 @@ module OData
           schema_object_name, key_values, keys = extract_schema_object_name_and_key_values_and_keys(str)
           return nil if schema_object_name.blank?
 
+          # Note: Any aliased entity types need to be singularized because of this.
           entity_type = query.data_services.find_entity_type(schema_object_name.singularize)
           return nil if entity_type.blank?
 

--- a/lib/o_data/core/segments/entity_type_segment.rb
+++ b/lib/o_data/core/segments/entity_type_segment.rb
@@ -23,7 +23,11 @@ module OData
         end
 
         def valid?(results)
-          results.present?
+          if countable?
+            results.is_a?(Array) || results.is_a?(ActiveRecord::Relation)
+          else
+            !results.nil?
+          end
         end
       end # EntityTypeSegment
     end # Segments

--- a/lib/o_data/edm/data_services.rb
+++ b/lib/o_data/edm/data_services.rb
@@ -35,7 +35,7 @@ module OData
 
       def to_json
         @entity_types.map do |entity|
-          { name: entity.plural_name, kind: 'EntitySet', url: entity.plural_name }
+          { name: entity.plural_name, kind: 'EntitySet', url: entity.url_name }
         end
       end
     end

--- a/spec/fixtures/files/metadata_after_hook.xml
+++ b/spec/fixtures/files/metadata_after_hook.xml
@@ -6,7 +6,7 @@
         <Key>
           <PropertyRef Name="Id"/>
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
         <Property Name="Name" Type="Edm.String" Nullable="true"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
@@ -15,7 +15,7 @@
         <Key>
           <PropertyRef Name="Id"/>
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
         <Property Name="Name" Type="TestType" Nullable="true"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>

--- a/spec/fixtures/files/metadata_basic.xml
+++ b/spec/fixtures/files/metadata_basic.xml
@@ -6,7 +6,7 @@
         <Key>
           <PropertyRef Name="Id"/>
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
         <Property Name="Name" Type="Edm.String" Nullable="true"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
@@ -15,7 +15,7 @@
         <Key>
           <PropertyRef Name="Id"/>
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
         <Property Name="Name" Type="Edm.String" Nullable="true"/>
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>

--- a/spec/fixtures/files/metadata_with_extra_tags.xml
+++ b/spec/fixtures/files/metadata_with_extra_tags.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Test" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="ActiveBar">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="true"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="ActiveFoo" BaseType="Test">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="true"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="TestService">
+        <EntitySet Name="ActiveBars" EntityType="Test.ActiveBar">
+        </EntitySet>
+        <EntitySet Name="ActiveFoos" EntityType="Test.ActiveFoo">
+        </EntitySet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -236,6 +236,18 @@ describe OData::ActiveRecordSchema::Base do
           end
         end
       end
+
+      context "navigation" do
+        context "$count" do
+          let(:path) { "#{root}/ActiveFoos/$count" }
+          it { expect_output("2") }
+        end
+
+        context "$value" do
+          let(:path) { "#{root}/ActiveFoos(1)/Name/$value" }
+          it { expect_output("test 1") }
+        end
+      end
     end
   end
 end

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -74,6 +74,7 @@ describe OData::ActiveRecordSchema::Base do
 
         it "renders with custom EntityTypes" do
           schema.add_entity_type(ActiveFoo, name: "CustomFoo",
+                                            url_name: "CustomFooUrl",
                                             reflect_on_associations: false)
           schema.add_entity_type(ActiveBar, name: "CustomBar",
                                             reflect_on_associations: false)
@@ -82,7 +83,7 @@ describe OData::ActiveRecordSchema::Base do
           expect_output({
             "@odata.context" => "http://www.example.com/odata/$metadata",
             value: [
-              { name: "CustomFoos", kind: "EntitySet", url: "CustomFoos" },
+              { name: "CustomFoos", kind: "EntitySet", url: "CustomFooUrl" },
               { name: "CustomBars", kind: "EntitySet", url: "CustomBars" }
             ]
           }.to_json)
@@ -215,6 +216,24 @@ describe OData::ActiveRecordSchema::Base do
               { Id: 1, Name: "test 1", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" }
             ]
           }.to_json)
+        end
+
+        context "with aliased URLs" do
+          let(:path) { "#{root}/CustomFooUrl" }
+
+          it "renders as expected" do
+            schema.add_entity_type(ActiveFoo, url_name: "CustomFooUrl",
+                                              reflect_on_associations: false)
+            refresh_schema(schema)
+
+            expect_output({
+              "@odata.context" => "http://www.example.com/odata/$metadata#ActiveFoos",
+              value: [
+                { Id: 1, Name: "test 1", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+                { Id: 2, Name: "test 2", CreatedAt: "2020-01-01T12:00:00Z", UpdatedAt: "2020-01-01T12:00:00Z" },
+              ]
+            }.to_json)
+          end
         end
       end
     end

--- a/spec/requests/active_record_request_spec.rb
+++ b/spec/requests/active_record_request_spec.rb
@@ -114,6 +114,23 @@ describe OData::ActiveRecordSchema::Base do
           expect_output(file_fixture("metadata_after_hook.xml").read)
         end
       end
+
+      context "with extra tags" do
+        let(:options) do
+          {
+            transformers: {
+              metadata: lambda do |schema|
+                schema.entity_types["ActiveFoo"].extra_tags = {BaseType: "Test"}
+                schema
+              end
+            }
+          }
+        end
+
+        it "renders as expected" do
+          expect_output(file_fixture("metadata_with_extra_tags.xml").read)
+        end
+      end
     end
 
     context "resource" do


### PR DESCRIPTION
So much gratitude for your work reviewing these PRs so far @Claun. We're glad we didn't have to create yet another fork in this chain of odata_server forks and muddy the FOSS water 😉 

This is the **last** of the PRs that I planned to submit in order to support the features we need for NEMO. I'm sure there will be other little things eventually, but this is it for now.

### Changes

I recommend viewing commit diffs individually, since they are each fairly standalone.

#### Main change

1. Register a `refresh_schema` hook (first, before the others)
    - Allows updating your schema at request time, instead of being generated during initialization
    - Benefits documented in the previous PR #4

Here's what our app code looks like to take advantage of this hook (see [rails docs](https://edgeguides.rubyonrails.org/engines.html#overriding-models-and-controllers) for how to load this open-class override automatically):

```ruby
ODataController.class_eval do
  # This is called in before_action by odata_server.
  def refresh_schema
    schema = OData::ActiveRecordSchema::Base.new(...)

    # ... Do what's needed to modify the schema, documented in the README.

    ODataController.data_services.clear_schemas
    ODataController.data_services.append_schemas([schema])
  end
end
```

#### Supporting tweaks

1. Use 64-bit integer types
    - Seems more conventional in 2020
1. Add `:id` type
    - Simple and useful, part of the OData spec
1. Allow `extra_tags` for EntityType XML
    - Allows adding custom tags on certain data, e.g. `OpenType: true`
1. Accept (or sanitize) `url_name` for root JSON entities
    - Allows using a different URL path for entities in case the name is not URL-safe
    - e.g. `{ "name": "A name! with spaces", "url": "a-name-with-spaces" }`
1. Fix an old validity check to allow empty arrays
    - The old check causes a 500 error if it gets an empty array